### PR TITLE
Add link support to SVG Inline block

### DIFF
--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -42,7 +42,7 @@
     },
     "linkTarget": {
       "type": "string",
-      "default": "_self"
+      "default": ""
     },
     "nofollow": {
       "type": "boolean",

--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -51,6 +51,9 @@
     "sponsored": {
       "type": "boolean",
       "default": false
+    },
+    "linkLabel": {
+      "type": "string"
     }
   },
   "supports": {
@@ -65,5 +68,6 @@
     }
   },
   "editorScript": "file:../../../dist/safe-svg-block.js",
+  "editorStyle": "file:../../../dist/safe-svg-block.css",
   "style": "file:../../../dist/safe-svg-block-frontend.css"
 }

--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -36,6 +36,21 @@
     },
     "imageSizes": {
       "type": "object"
+    },
+    "href": {
+      "type": "string"
+    },
+    "linkTarget": {
+      "type": "string",
+      "default": "_self"
+    },
+    "nofollow": {
+      "type": "boolean",
+      "default": false
+    },
+    "sponsored": {
+      "type": "boolean",
+      "default": false
     }
   },
   "supports": {

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -15,6 +15,7 @@ import {
 	PanelBody,
 	Dropdown,
 	ToolbarButton,
+	TextControl,
 } from '@wordpress/components';
 import { link } from '@wordpress/icons';
 import {
@@ -59,6 +60,7 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 		linkTarget,
 		nofollow,
 		sponsored,
+		linkLabel,
 	} = attributes;
 
 	const blockProps = useBlockProps(
@@ -251,6 +253,12 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 										]}
 										onClose={onClose}
 									/>
+									<TextControl
+										label={__('Link Label (aria-label)', 'safe-svg')}
+										value={linkLabel}
+										onChange={(value) => setAttributes({ linkLabel: value })}
+										help={__('Provides an accessible label for screen readers.', 'safe-svg')}
+									/>
 								</div>
 							)}
 						/>
@@ -274,23 +282,24 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 			{svgURL &&
 				<div {...containerBlockProps}>
 					{href ? (
-						<a
-							href={href}
-							target={linkTarget}
-							rel={[nofollow ? 'nofollow' : '', sponsored ? 'sponsored' : ''].filter(Boolean).join(' ') || undefined}
+						<div
+							style={style}
+							className={classnames(
+								'safe-svg-inside',
+								getColorClassName('color', textColor) || ''
+							)}
 						>
-							<div
-								style={style}
-								className={classnames(
-									'safe-svg-inside',
-									getColorClassName('color', textColor) || ''
-								)}
+							<a
+								href={href}
+								target={linkTarget}
+								rel={[nofollow ? 'nofollow' : '', sponsored ? 'sponsored' : '', linkTarget === '_blank' ? 'noopener' : ''].filter(Boolean).join(' ') || undefined}
+								aria-label={linkLabel || undefined}
 							>
 								<ReactSVG src={svgURL} beforeInjection={(svg) => {
 									svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
 								}} />
-							</div>
-						</a>
+							</a>
+						</div>
 					) : (
 						<div
 							style={style}
@@ -337,6 +346,7 @@ SafeSvgBlockEdit.propTypes = {
 		linkTarget: PropTypes.string,
 		nofollow: PropTypes.bool,
 		sponsored: PropTypes.bool,
+		linkLabel: PropTypes.string,
 	}).isRequired,
 	className: PropTypes.string,
 	clientId: PropTypes.string,

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -13,7 +13,10 @@ import { __ } from '@wordpress/i18n';
 import {
 	Placeholder,
 	PanelBody,
+	Dropdown,
+	ToolbarButton,
 } from '@wordpress/components';
+import { link } from '@wordpress/icons';
 import {
 	useBlockProps,
 	BlockControls,
@@ -22,6 +25,7 @@ import {
 	__experimentalImageSizeControl as ImageSizeControl,
 	MediaReplaceFlow,
 	MediaPlaceholder,
+	LinkControl,
 	getColorClassName,
 } from '@wordpress/block-editor';
 
@@ -51,6 +55,10 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 		dimensionWidth,
 		dimensionHeight,
 		textColor,
+		href,
+		linkTarget,
+		nofollow,
+		sponsored,
 	} = attributes;
 
 	const blockProps = useBlockProps(
@@ -191,6 +199,61 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 							accept={ALLOWED_MEDIA_TYPES}
 							onSelect={onSelectImage}
 							onError={onError} />
+						<Dropdown
+							className="safe-svg-link-dropdown"
+							renderToggle={({ isOpen, onToggle }) => (
+								<ToolbarButton
+									icon={link}
+									label={__('Link', 'safe-svg')}
+									onClick={onToggle}
+									aria-expanded={isOpen}
+								/>
+							)}
+							renderContent={({ onClose }) => (
+								<div className="block-editor-link-control">
+									<LinkControl
+										value={{
+											url: href,
+											opensInNewTab: linkTarget === '_blank',
+											nofollow: !!nofollow,
+											sponsored: !!sponsored,
+										}}
+										onChange={(linkSettings) => {
+											setAttributes({
+												href: linkSettings.url,
+												linkTarget: linkSettings.opensInNewTab ? '_blank' : '_self',
+												nofollow: !!linkSettings.nofollow,
+												sponsored: !!linkSettings.sponsored,
+											});
+										}}
+										settings={[
+											{
+												id: 'opensInNewTab',
+												title: __(
+													'Open in new tab',
+													'safe-svg'
+												),
+											},
+											{
+												id: 'nofollow',
+												title: __(
+													'Add rel="nofollow"',
+													'safe-svg'
+												),
+											},
+											{
+												id: 'sponsored',
+												title: __(
+													'Add rel="sponsored"',
+													'safe-svg'
+												),
+											},
+										]}
+										onClose={onClose}
+									/>
+								</div>
+							)}
+						/>
 					</BlockControls>
 				</>
 			}
@@ -210,17 +273,37 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 
 			{svgURL &&
 				<div {...containerBlockProps}>
-					<div
-						style={style}
-						className={classnames(
-							'safe-svg-inside',
-							getColorClassName('color', textColor) || ''
-						)}
-					>
-						<ReactSVG src={svgURL} beforeInjection={(svg) => {
-							svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
-						}} />
-					</div>
+					{href ? (
+						<a
+							href={href}
+							target={linkTarget}
+							rel={[nofollow ? 'nofollow' : '', sponsored ? 'sponsored' : ''].filter(Boolean).join(' ') || undefined}
+						>
+							<div
+								style={style}
+								className={classnames(
+									'safe-svg-inside',
+									getColorClassName('color', textColor) || ''
+								)}
+							>
+								<ReactSVG src={svgURL} beforeInjection={(svg) => {
+									svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
+								}} />
+							</div>
+						</a>
+					) : (
+						<div
+							style={style}
+							className={classnames(
+								'safe-svg-inside',
+								getColorClassName('color', textColor) || ''
+							)}
+						>
+							<ReactSVG src={svgURL} beforeInjection={(svg) => {
+								svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
+							}} />
+						</div>
+					)}
 				</div>
 			}
 
@@ -250,6 +333,10 @@ SafeSvgBlockEdit.propTypes = {
 		dimensionWidth: PropTypes.number,
 		dimensionHeight: PropTypes.number,
 		imageSizes: PropTypes.object,
+		href: PropTypes.string,
+		linkTarget: PropTypes.string,
+		nofollow: PropTypes.bool,
+		sponsored: PropTypes.bool,
 	}).isRequired,
 	className: PropTypes.string,
 	clientId: PropTypes.string,

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -223,7 +223,7 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 										onChange={(linkSettings) => {
 											setAttributes({
 												href: linkSettings.url,
-												linkTarget: linkSettings.opensInNewTab ? '_blank' : '_self',
+												linkTarget: linkSettings.opensInNewTab ? '_blank' : '',
 												nofollow: !!linkSettings.nofollow,
 												sponsored: !!linkSettings.sponsored,
 											});
@@ -231,7 +231,7 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 										onRemove={() => {
 											setAttributes({
 												href: '',
-												linkTarget: '_self',
+												linkTarget: '',
 												nofollow: false,
 												sponsored: false,
 											});

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -228,6 +228,14 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 												sponsored: !!linkSettings.sponsored,
 											});
 										}}
+										onRemove={() => {
+											setAttributes({
+												href: '',
+												linkTarget: '_self',
+												nofollow: false,
+												sponsored: false,
+											});
+										}}
 										settings={[
 											{
 												id: 'opensInNewTab',
@@ -281,38 +289,17 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 
 			{svgURL &&
 				<div {...containerBlockProps}>
-					{href ? (
-						<div
-							style={style}
-							className={classnames(
-								'safe-svg-inside',
-								getColorClassName('color', textColor) || ''
-							)}
-						>
-							<a
-								href={href}
-								target={linkTarget}
-								rel={[nofollow ? 'nofollow' : '', sponsored ? 'sponsored' : '', linkTarget === '_blank' ? 'noopener' : ''].filter(Boolean).join(' ') || undefined}
-								aria-label={linkLabel || undefined}
-							>
-								<ReactSVG src={svgURL} beforeInjection={(svg) => {
-									svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
-								}} />
-							</a>
-						</div>
-					) : (
-						<div
-							style={style}
-							className={classnames(
-								'safe-svg-inside',
-								getColorClassName('color', textColor) || ''
-							)}
-						>
-							<ReactSVG src={svgURL} beforeInjection={(svg) => {
-								svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
-							}} />
-						</div>
-					)}
+					<div
+						style={style}
+						className={classnames(
+							'safe-svg-inside',
+							getColorClassName('color', textColor) || ''
+						)}
+					>
+						<ReactSVG src={svgURL} beforeInjection={(svg) => {
+							svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
+						}} />
+					</div>
 				</div>
 			}
 

--- a/includes/blocks/safe-svg/editor.scss
+++ b/includes/blocks/safe-svg/editor.scss
@@ -1,0 +1,6 @@
+.safe-svg-link-dropdown {
+    align-self: center;
+    border-left: 1px solid #1e1e1e;
+    padding-left: 6px;
+    margin-left: 6px;
+}

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -1,3 +1,17 @@
+.wp-block-safe-svg-svg-icon a {
+    align-self: center;
+}
+
+.components-dropdown {
+    align-self: center;
+}
+
+.safe-svg-link-dropdown {
+    border-left: 1px solid #1e1e1e;
+    padding-left: 6px;
+    margin-left: 6px;
+}
+
 .safe-svg-cover {
     text-align: center;
 

--- a/includes/blocks/safe-svg/frontend.scss
+++ b/includes/blocks/safe-svg/frontend.scss
@@ -2,16 +2,6 @@
     align-self: center;
 }
 
-.components-dropdown {
-    align-self: center;
-}
-
-.safe-svg-link-dropdown {
-    border-left: 1px solid #1e1e1e;
-    padding-left: 6px;
-    margin-left: 6px;
-}
-
 .safe-svg-cover {
     text-align: center;
 

--- a/includes/blocks/safe-svg/index.js
+++ b/includes/blocks/safe-svg/index.js
@@ -15,8 +15,7 @@ import edit from './edit';
 import save from './save';
 import block from './block.json';
 
-/* Uncomment for CSS overrides in the admin */
-import './frontend.scss';
+import './editor.scss';
 
 /**
  * Register block

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -54,16 +54,28 @@ function render_block_callback( $attributes ) {
 
 	if ( ! empty( $attributes['href'] ) ) {
 		$link_target = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
-		$rel         = trim(
-			( ! empty( $attributes['nofollow'] ) ? 'nofollow' : '' )
-			. ' '
-			. ( ! empty( $attributes['sponsored'] ) ? 'sponsored' : '' )
-		);
-		$contents    = sprintf(
-			'<a href="%1$s" target="%2$s" rel="%3$s">%4$s</a>',
+
+		$rel_parts = array();
+		if ( ! empty( $attributes['nofollow'] ) ) {
+			$rel_parts[] = 'nofollow';
+		}
+		if ( ! empty( $attributes['sponsored'] ) ) {
+			$rel_parts[] = 'sponsored';
+		}
+		if ( '_blank' === $link_target ) {
+			$rel_parts[] = 'noopener';
+		}
+		$rel      = implode( ' ', $rel_parts );
+		$rel_attr = $rel ? ' rel="' . esc_attr( $rel ) . '"' : '';
+
+		$aria_label = ! empty( $attributes['linkLabel'] ) ? ' aria-label="' . esc_attr( $attributes['linkLabel'] ) . '"' : '';
+
+		$contents = sprintf(
+			'<a href="%1$s" target="%2$s"%3$s%4$s>%5$s</a>',
 			esc_url( $attributes['href'] ),
 			esc_attr( $link_target ),
-			esc_attr( $rel ),
+			$rel_attr,
+			$aria_label,
 			$contents
 		);
 	}

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -53,7 +53,7 @@ function render_block_callback( $attributes ) {
 	$class_name = apply_filters( 'safe_svg_inline_class', 'safe-svg-inline' );
 
 	if ( ! empty( $attributes['href'] ) ) {
-		$link_target = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+		$link_target = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : false;
 
 		$rel_parts = array();
 		if ( ! empty( $attributes['nofollow'] ) ) {
@@ -68,9 +68,9 @@ function render_block_callback( $attributes ) {
 		$aria_label = ! empty( $attributes['linkLabel'] ) ? ' aria-label="' . esc_attr( $attributes['linkLabel'] ) . '"' : '';
 
 		$contents = sprintf(
-			'<a href="%1$s" target="%2$s"%3$s%4$s>%5$s</a>',
+			'<a href="%1$s"%2$s%3$s%4$s>%5$s</a>',
 			esc_url( $attributes['href'] ),
-			esc_attr( $link_target ),
+			$link_target ? ' target="' . esc_attr( $link_target ) . '"' : '',
 			$rel_attr,
 			$aria_label,
 			$contents

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -52,6 +52,22 @@ function render_block_callback( $attributes ) {
 	 */
 	$class_name = apply_filters( 'safe_svg_inline_class', 'safe-svg-inline' );
 
+	if ( ! empty( $attributes['href'] ) ) {
+		$link_target = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : '_self';
+		$rel         = trim(
+			( ! empty( $attributes['nofollow'] ) ? 'nofollow' : '' )
+			. ' '
+			. ( ! empty( $attributes['sponsored'] ) ? 'sponsored' : '' )
+		);
+		$contents    = sprintf(
+			'<a href="%1$s" target="%2$s" rel="%3$s">%4$s</a>',
+			esc_url( $attributes['href'] ),
+			esc_attr( $link_target ),
+			esc_attr( $rel ),
+			$contents
+		);
+	}
+
 	/**
 	 * The wrapper markup.
 	 *

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -62,9 +62,6 @@ function render_block_callback( $attributes ) {
 		if ( ! empty( $attributes['sponsored'] ) ) {
 			$rel_parts[] = 'sponsored';
 		}
-		if ( '_blank' === $link_target ) {
-			$rel_parts[] = 'noopener';
-		}
 		$rel      = implode( ' ', $rel_parts );
 		$rel_attr = $rel ? ' rel="' . esc_attr( $rel ) . '"' : '';
 


### PR DESCRIPTION
### Description of the Change
Added `href`, `linkTarget`, `nofollow`, and `sponsored` attributes to the Safe SVG block, allowing users to wrap inline SVGs in links — similar to the core Image block.

Closes #282 

### How to test the Change
1. Insert an Inline SVG block and select an SVG
2. Click the link button (chain icon) in the block toolbar
3. Enter a URL, toggle Open in new tab, Add rel="nofollow", and/or Add rel="sponsored"
4. Publish the post and verify the SVG is wrapped in an <a> tag with correct href, target, and rel attributes

### Changelog Entry
> Added - Link support for the SVG Inline block, including URL input, new tab toggle, and nofollow/sponsored rel options

### Credits
Props @vegetable-bits

### Checklist:
- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly.
- [X] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [X] All new and existing tests pass.
