### PR TITLE
WP Compatibility Check Against WP Core 7.1

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#6.9-branch'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
 
     steps:

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Safe SVG ===
 Contributors:      10up, enshrined, jeffpaul
 Tags:              svg, security, media, vector, mime
-Requires at least: 6.6
+Requires at least: 6.9
 Requires PHP:      7.4
 Tested up to:      7.1
 Stable tag:        2.4.0

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      10up, enshrined, jeffpaul
 Tags:              svg, security, media, vector, mime
 Requires at least: 6.6
 Requires PHP:      7.4
-Tested up to:      7.0
+Tested up to:      7.1
 Stable tag:        2.4.0
 License:           GPL-2.0-or-later
 License URI:       https://spdx.org/licenses/GPL-2.0-or-later.html

--- a/tests/unit/test-plugin-headers.php
+++ b/tests/unit/test-plugin-headers.php
@@ -454,8 +454,8 @@ class PluginHeadersTests extends TestCase {
 		$this->assertNotFalse( $cypress_contents, 'Unable to read cypress.yml.' );
 
 		// Extract the minimum WordPress version from the "WP minimum" matrix entry in cypress.yml.
-		// Looking for: - {name: 'WP minimum', version: 'WordPress/WordPress#6.6'}
-		$pattern = '/\-\s*\{\s*name:\s*\'WP minimum\'\s*,\s*version:\s*\'WordPress\/WordPress#([\d.]+)\'/';
+		// Looking for: - {name: 'WP minimum', version: 'WordPress/WordPress#x.x-branch'}
+		$pattern = '/\-\s*\{\s*name:\s*\'WP minimum\'\s*,\s*version:\s*\'WordPress\/WordPress#([\d.]+)\-branch\'/';
 		preg_match( $pattern, $cypress_contents, $cypress_match );
 		$this->assertNotEmpty( $cypress_match, 'Unable to parse minimum WordPress version from the "WP minimum" matrix entry in cypress.yml.' );
 		$cypress_min_wp = $cypress_match[1];


### PR DESCRIPTION
### Description of the Change
Tested compatibility against WP Core 7.1 RC1. The plugin functions as expected with the 7.1 RC1 

Closes #319 

### How to test the Change

1. Update WP Core version to 7.1 RC1 using any methods described [here](https://wordpress.org/news/2026/08/wordpress-7-1-release-candidate-1/)
2. Navigate to any screens and there should be no warnings and/or errors.
3. The plugin functionality works as expected

### Changelog Entry

> Developer - Bumped up Tested up to from 7.0 to 7.1

### Credits

Props @zamanq 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
