### PR TITLE
Update SVG Sanitizer library from v0.22.0 to v1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	],
 	"require": {
 		"php": ">=7.4",
-		"enshrined/svg-sanitize": "^0.22.0"
+		"enshrined/svg-sanitize": "^1.0.0"
 	},
 	"require-dev": {
 		"10up/phpcs-composer": "dev-trunk",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b0837aa030c0147b444e8c0ae9d5c2e",
+    "content-hash": "5d9400da71a43ab30b21ed52bf6763ee",
     "packages": [
         {
             "name": "enshrined/svg-sanitize",
-            "version": "0.22.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/darylldoyle/svg-sanitizer.git",
-                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500"
+                "reference": "f3300fcd1bbf67d205b52217c75d0f7d6a8c47ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/0afa95ea74be155a7bcd6c6fb60c276c39984500",
-                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/f3300fcd1bbf67d205b52217c75d0f7d6a8c47ff",
+                "reference": "f3300fcd1bbf67d205b52217c75d0f7d6a8c47ff",
                 "shasum": ""
             },
             "require": {
@@ -47,9 +47,9 @@
             "description": "An SVG sanitizer for PHP",
             "support": {
                 "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
-                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.22.0"
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/1.0.0"
             },
-            "time": "2025-08-12T10:13:48+00:00"
+            "time": "2026-09-01T09:35:47+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Description of the Change

Updated the `enshrined/svg-sanitize` package from version `^0.22.0` to `^1.0.0` in composer.json to ensure we use the latest release.

There's a number of fixes in that [release](https://github.com/darylldoyle/svg-sanitizer/releases/tag/1.0.0) so it will be good to pull those in.

### How to test the Change

This update pulls in a new version of the library we use for sanitization so basic smoke testing of the entire plugin is needed, ensuring SVG uploads still work as expected.

### Changelog Entry

> Security - Updates the underlying `enshrined/svg-sanitize` package to pull in a security fixes

### Credits

Props @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
