### PR TITLE
Render the SVG block in a shadow DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ add_filter( 'svg_allowed_tags', function ( $tags ) {
 } );
 ```
 
+### Can my theme style an inline SVG?
+
+Mostly, yes. The Inline SVG block renders an SVG that carries its own `<style>` element inside a shadow root, because CSS inside an inline SVG is otherwise applied to the whole page rather than just the SVG. Stylesheets cannot reach into a shadow root, so theme CSS such as `.entry-content svg { fill: red; }` will not apply to those SVGs.
+
+Inherited properties still cross the boundary, so setting `color` on an ancestor and using `currentColor` inside the SVG works, as do CSS custom properties. SVGs that do not contain a `<style>` element are rendered exactly as before and can be styled normally.
+
+To turn isolation off, at the cost of allowing an SVG's CSS to affect the rest of the page:
+
+```php
+add_filter( 'safe_svg_inline_use_shadow_dom', '__return_false' );
+```
+
 ### Why doesn't Safe SVG globally enable SVG uploads?
 
 Safe SVG only allows SVGs through upload paths it can actively sanitize. While most WordPress uploads use standard functions like `wp_handle_upload()` (which Safe SVG hooks), plugins and themes can create custom upload paths by calling WordPress's underlying `_wp_handle_upload()` function with arbitrary action parameters.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ add_filter( 'svg_allowed_tags', function ( $tags ) {
 
 Mostly, yes. The Inline SVG block renders an SVG that carries its own `<style>` element inside a shadow root, because CSS inside an inline SVG is otherwise applied to the whole page rather than just the SVG. Stylesheets cannot reach into a shadow root, so theme CSS such as `.entry-content svg { fill: red; }` will not apply to those SVGs.
 
-Inherited properties still cross the boundary, so setting `color` on an ancestor and using `currentColor` inside the SVG works, as do CSS custom properties. SVGs that do not contain a `<style>` element are rendered exactly as before and can be styled normally.
+Inherited properties still cross the boundary, so setting `color` on an ancestor and using `currentColor` inside the SVG works, as do CSS custom properties. SVGs that do not contain a `<style>` element are rendered without the shadow root and can be styled by theme stylesheets.
 
 To turn isolation off, at the cost of allowing an SVG's CSS to affect the rest of the page:
 

--- a/includes/blocks/safe-svg/block.json
+++ b/includes/blocks/safe-svg/block.json
@@ -69,5 +69,6 @@
   },
   "editorScript": "file:../../../dist/safe-svg-block.js",
   "editorStyle": "file:../../../dist/safe-svg-block.css",
+  "viewScript": "file:../../../dist/safe-svg-block-frontend.js",
   "style": "file:../../../dist/safe-svg-block-frontend.css"
 }

--- a/includes/blocks/safe-svg/edit.js
+++ b/includes/blocks/safe-svg/edit.js
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { ReactSVG } from 'react-svg'
 import classnames from 'classnames';
 
 /**
@@ -29,6 +28,11 @@ import {
 	LinkControl,
 	getColorClassName,
 } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import InlineSvg from './inline-svg';
 
 /**
  * Edit component.
@@ -296,9 +300,10 @@ const SafeSvgBlockEdit = ({ attributes, setAttributes }) => {
 							getColorClassName('color', textColor) || ''
 						)}
 					>
-						<ReactSVG src={svgURL} beforeInjection={(svg) => {
-							svg.setAttribute('style', `width: ${dimensionWidth}px; height: ${dimensionHeight}px;`);
-						}} />
+						<InlineSvg
+							src={svgURL}
+							width={dimensionWidth}
+							height={dimensionHeight} />
 					</div>
 				</div>
 			}

--- a/includes/blocks/safe-svg/frontend.js
+++ b/includes/blocks/safe-svg/frontend.js
@@ -1,3 +1,74 @@
-/* global safe-svg_personalizer_params */
-/* eslint-disable camelcase */
 import './frontend.scss';
+
+/**
+ * Attach shadow roots the HTML parser didn't.
+ */
+const SELECTOR = '.safe-svg-shadow-host > template[shadowrootmode]';
+
+/**
+ * Move a template's content into a shadow root on its parent.
+ *
+ * @param {HTMLTemplateElement} template The declarative shadow root template.
+ */
+const attach = ( template ) => {
+	const host = template.parentElement;
+
+	if ( ! host || host.shadowRoot ) {
+		return;
+	}
+
+	try {
+		const mode =
+			template.getAttribute( 'shadowrootmode' ) === 'closed'
+				? 'closed'
+				: 'open';
+
+		host.attachShadow( { mode } ).appendChild( template.content );
+		template.remove();
+	} catch ( e ) {
+		// The host can't take a shadow root. Leave the template as it is rather
+		// than moving the SVG into the light DOM, where its CSS would leak.
+	}
+};
+
+/**
+ * Upgrade every unattached template within a root.
+ *
+ * @param {ParentNode} root The subtree to search.
+ */
+const upgrade = ( root ) => {
+	if ( root.matches && root.matches( SELECTOR ) ) {
+		attach( root );
+	}
+
+	if ( root.querySelectorAll ) {
+		root.querySelectorAll( SELECTOR ).forEach( attach );
+	}
+};
+
+/**
+ * Upgrade what's on the page, then watch for anything added later.
+ */
+const start = () => {
+	upgrade( document );
+
+	// Content can be injected at any point in a page's life, so keep watching.
+	new MutationObserver( ( mutations ) => {
+		mutations.forEach( ( { addedNodes } ) => {
+			addedNodes.forEach( ( node ) => {
+				if ( node.nodeType === Node.ELEMENT_NODE ) {
+					upgrade( node );
+				}
+			} );
+		} );
+	} ).observe( document.documentElement, {
+		childList: true,
+		subtree: true,
+	} );
+};
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', start );
+} else {
+	start();
+}

--- a/includes/blocks/safe-svg/inline-svg.js
+++ b/includes/blocks/safe-svg/inline-svg.js
@@ -10,6 +10,8 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * The styles applied inside the shadow root.
+ *
+ * Keep in sync with the safe_svg_inline_shadow_styles default in register.php.
  */
 const SHADOW_STYLES =
 	'svg{fill:currentColor;width:100%;height:100%;max-width:100%;max-height:100%}';

--- a/includes/blocks/safe-svg/inline-svg.js
+++ b/includes/blocks/safe-svg/inline-svg.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * The styles applied inside the shadow root.
+ */
+const SHADOW_STYLES =
+	'svg{fill:currentColor;width:100%;height:100%;max-width:100%;max-height:100%}';
+
+/**
+ * Check whether an SVG carries its own stylesheet.
+ *
+ * @param {string} markup The SVG markup.
+ * @return {boolean} True if the SVG contains a style element.
+ */
+const hasStylesheet = (markup) =>
+	/<\s*(?:[a-z0-9_.\-]+:)?style\b/i.test(markup);
+
+/**
+ * Render an SVG inline, isolating it when it brings its own CSS.
+ *
+ * @param {Object} props        The component props.
+ * @param {string} props.src    The SVG URL.
+ * @param {number} props.width  Width to render the SVG at, in pixels.
+ * @param {number} props.height Height to render the SVG at, in pixels.
+ * @return {Function} The SVG host element.
+ */
+const InlineSvg = ({ src, width, height }) => {
+	const hostRef = useRef(null);
+	const attachedRef = useRef(false);
+	const [markup, setMarkup] = useState('');
+
+	useEffect(() => {
+		if (!src) {
+			setMarkup('');
+			return undefined;
+		}
+
+		const controller = new AbortController();
+
+		fetch(src, { signal: controller.signal })
+			.then((response) => (response.ok ? response.text() : ''))
+			.then(setMarkup)
+			.catch(() => {
+				// Aborted, or the file couldn't be read. Leave the preview empty.
+			});
+
+		return () => controller.abort();
+	}, [src]);
+
+	useEffect(() => {
+		const host = hostRef.current;
+
+		if (!host) {
+			return;
+		}
+
+		// A shadow root can't be detached once attached, so once this host has
+		// one it keeps rendering through it whatever the next SVG looks like.
+		const shadow =
+			host.shadowRoot ||
+			(hasStylesheet(markup) ? host.attachShadow({ mode: 'open' }) : null);
+
+		// The file was sanitized on upload, which is what makes it safe to inline
+		// here, exactly as the front end inlines the same bytes.
+		if (shadow) {
+			attachedRef.current = true;
+			shadow.innerHTML = `<style>${SHADOW_STYLES}</style>${markup}`;
+			host.innerHTML = '';
+		} else {
+			host.innerHTML = markup;
+		}
+
+		const svg = (shadow || host).querySelector('svg');
+
+		if (svg && width && height) {
+			svg.setAttribute('style', `width: ${width}px; height: ${height}px;`);
+		}
+	}, [markup, width, height]);
+
+	const isolated = attachedRef.current || hasStylesheet(markup);
+
+	return (
+		<span
+			className="safe-svg-shadow-guard"
+			style={{
+				display: 'block',
+				height: '100%',
+				contain: isolated ? 'paint' : undefined,
+			}}
+		>
+			<span
+				ref={hostRef}
+				className="safe-svg-shadow-host"
+				style={{ display: 'block', height: '100%' }}
+			/>
+		</span>
+	);
+};
+
+InlineSvg.propTypes = {
+	src: PropTypes.string,
+	width: PropTypes.number,
+	height: PropTypes.number,
+};
+
+export default InlineSvg;

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -52,6 +52,8 @@ function render_block_callback( $attributes ) {
 	 */
 	$class_name = apply_filters( 'safe_svg_inline_class', 'safe-svg-inline' );
 
+	$has_stylesheet = svg_has_stylesheet( $contents );
+
 	/**
 	 * Whether to isolate this inline SVG inside a shadow root.
 	 *
@@ -65,10 +67,10 @@ function render_block_callback( $attributes ) {
 	 */
 	$use_shadow_dom = (bool) apply_filters(
 		'safe_svg_inline_use_shadow_dom',
-		svg_has_stylesheet( $contents ),
+		$has_stylesheet,
 		$contents,
 		$attributes['imageID'],
-		svg_has_stylesheet( $contents )
+		$has_stylesheet
 	);
 
 	if ( $use_shadow_dom ) {

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -142,6 +142,8 @@ function render_block_callback( $attributes ) {
 /**
  * Check whether an SVG carries its own stylesheet.
  *
+ * Keep in sync with hasStylesheet() in inline-svg.js.
+ *
  * @since x.x.x
  *
  * @param string $contents The SVG contents.
@@ -175,8 +177,10 @@ function wrap_in_shadow_root( $svg, $attachment_id ): string {
 		$attachment_id
 	);
 
+	// Stop an unsanitized SVG closing the shadow template early and escaping.
 	$svg = str_ireplace( '</template', '&lt;/template', $svg );
 
+	// Stop a filtered value closing the <style> and injecting markup.
 	$styles = str_replace( '<', '', $styles );
 
 	return sprintf(

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -52,6 +52,27 @@ function render_block_callback( $attributes ) {
 	 */
 	$class_name = apply_filters( 'safe_svg_inline_class', 'safe-svg-inline' );
 
+	/**
+	 * Whether to isolate this inline SVG inside a shadow root.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param bool   $use_shadow_dom Whether to isolate the SVG. Defaults to true
+	 *                               when the SVG carries its own stylesheet.
+	 * @param string $contents       The SVG contents.
+	 * @param int    $attachment_id  The ID of the attachment.
+	 */
+	$use_shadow_dom = (bool) apply_filters(
+		'safe_svg_inline_use_shadow_dom',
+		svg_has_stylesheet( $contents ),
+		$contents,
+		$attributes['imageID']
+	);
+
+	if ( $use_shadow_dom ) {
+		$contents = wrap_in_shadow_root( $contents, $attributes['imageID'] );
+	}
+
 	if ( ! empty( $attributes['href'] ) ) {
 		$link_target = ! empty( $attributes['linkTarget'] ) ? $attributes['linkTarget'] : false;
 
@@ -115,6 +136,53 @@ function render_block_callback( $attributes ) {
 		$contents,
 		$class_name,
 		$attributes['imageID']
+	);
+}
+
+/**
+ * Check whether an SVG carries its own stylesheet.
+ *
+ * @since x.x.x
+ *
+ * @param string $contents The SVG contents.
+ * @return bool True if the SVG contains a style element.
+ */
+function svg_has_stylesheet( $contents ): bool {
+	return 1 === preg_match( '#<\s*(?:[a-z0-9_.\-]+:)?style\b#i', $contents );
+}
+
+/**
+ * Wrap an SVG in a declarative shadow root.
+ *
+ * @since x.x.x
+ *
+ * @param string $svg           The SVG contents.
+ * @param int    $attachment_id The ID of the attachment.
+ * @return string The SVG wrapped in a shadow host.
+ */
+function wrap_in_shadow_root( $svg, $attachment_id ): string {
+	/**
+	 * The styles applied inside the inline SVG's shadow root.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $styles        The CSS to inject. Return an empty string for none.
+	 * @param int    $attachment_id The ID of the attachment.
+	 */
+	$styles = (string) apply_filters(
+		'safe_svg_inline_shadow_styles',
+		'svg{fill:currentColor;width:100%;height:100%;max-width:100%;max-height:100%}',
+		$attachment_id
+	);
+
+	$svg = str_ireplace( '</template', '&lt;/template', $svg );
+
+	$styles = str_replace( '<', '', $styles );
+
+	return sprintf(
+		'<span class="safe-svg-shadow-guard" style="display: block; height: 100%%; contain: paint;"><span class="safe-svg-shadow-host" style="display: block; height: 100%%;"><template shadowrootmode="open">%1$s%2$s</template></span></span>',
+		'' !== $styles ? '<style>' . $styles . '</style>' : '',
+		$svg
 	);
 }
 

--- a/includes/blocks/safe-svg/register.php
+++ b/includes/blocks/safe-svg/register.php
@@ -61,12 +61,14 @@ function render_block_callback( $attributes ) {
 	 *                               when the SVG carries its own stylesheet.
 	 * @param string $contents       The SVG contents.
 	 * @param int    $attachment_id  The ID of the attachment.
+	 * @param bool   $has_stylesheet Whether the SVG has a stylesheet.
 	 */
 	$use_shadow_dom = (bool) apply_filters(
 		'safe_svg_inline_use_shadow_dom',
 		svg_has_stylesheet( $contents ),
 		$contents,
-		$attributes['imageID']
+		$attributes['imageID'],
+		svg_has_stylesheet( $contents )
 	);
 
 	if ( $use_shadow_dom ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "classnames": "^2.5.1",
-        "react-svg": "^16.1.18",
         "svgo": "^3.3.5"
       },
       "devDependencies": {
@@ -1880,6 +1879,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
       "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -5013,9 +5013,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5037,9 +5034,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5061,9 +5055,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5085,9 +5076,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5109,9 +5097,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5133,9 +5118,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6102,16 +6084,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@tanem/svg-injector": {
-      "version": "10.1.68",
-      "resolved": "https://registry.npmjs.org/@tanem/svg-injector/-/svg-injector-10.1.68.tgz",
-      "integrity": "sha512-UkJajeR44u73ujtr5GVSbIlELDWD/mzjqWe54YMK61ljKxFcJoPd9RBSaO7xj02ISCWUqJW99GjrS+sVF0UnrA==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "content-type": "^1.0.5",
-        "tslib": "^2.6.2"
-      }
-    },
     "node_modules/@tannin/compile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -6466,7 +6438,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
-      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng=="
+      "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.11",
@@ -7048,9 +7021,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7065,9 +7035,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7082,9 +7049,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7099,9 +7063,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7116,9 +7077,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7133,9 +7091,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7150,9 +7105,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7167,9 +7119,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7184,9 +7133,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7201,9 +7147,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10771,6 +10714,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -16684,7 +16628,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.2",
@@ -17540,6 +17485,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -19092,6 +19038,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20815,6 +20762,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -20824,7 +20772,8 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -21124,6 +21073,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21135,6 +21085,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -21150,21 +21101,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-svg": {
-      "version": "16.1.33",
-      "resolved": "https://registry.npmjs.org/react-svg/-/react-svg-16.1.33.tgz",
-      "integrity": "sha512-XpKC3G1yZ+ay+lBy1KtJWKGEZGMI+291jEfHdyFfm6X3vMVg/mly2+JjPPCr4ihPElxaZI2z32n2RVV7+PFKVw==",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@tanem/svg-injector": "^10.1.68",
-        "@types/prop-types": "^15.7.11",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -21424,7 +21360,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -21982,6 +21919,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -24338,6 +24276,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsyringe": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
-    "react-svg": "^16.1.18",
     "svgo": "^3.3.5"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -73,7 +73,7 @@ They take one argument that must be returned. See below for examples:
 
 Mostly, yes. The Inline SVG block renders an SVG that carries its own `<style>` element inside a shadow root, because CSS inside an inline SVG is otherwise applied to the whole page rather than just the SVG. Stylesheets cannot reach into a shadow root, so theme CSS such as `.entry-content svg { fill: red; }` will not apply to those SVGs.
 
-Inherited properties still cross the boundary, so setting `color` on an ancestor and using `currentColor` inside the SVG works, as do CSS custom properties. SVGs that do not contain a `<style>` element are rendered exactly as before and can be styled normally.
+Inherited properties still cross the boundary, so setting `color` on an ancestor and using `currentColor` inside the SVG works, as do CSS custom properties. SVGs that do not contain a `<style>` element are rendered without the shadow root and can be styled by theme stylesheets.
 
 To turn isolation off, at the cost of allowing an SVG's CSS to affect the rest of the page:
 

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,16 @@ They take one argument that must be returned. See below for examples:
         return $tags;
     } );
 
+= Can my theme style an inline SVG? =
+
+Mostly, yes. The Inline SVG block renders an SVG that carries its own `<style>` element inside a shadow root, because CSS inside an inline SVG is otherwise applied to the whole page rather than just the SVG. Stylesheets cannot reach into a shadow root, so theme CSS such as `.entry-content svg { fill: red; }` will not apply to those SVGs.
+
+Inherited properties still cross the boundary, so setting `color` on an ancestor and using `currentColor` inside the SVG works, as do CSS custom properties. SVGs that do not contain a `<style>` element are rendered exactly as before and can be styled normally.
+
+To turn isolation off, at the cost of allowing an SVG's CSS to affect the rest of the page:
+
+    add_filter( 'safe_svg_inline_use_shadow_dom', '__return_false' );
+
 = Why doesn't Safe SVG globally enable SVG uploads? =
 
 Safe SVG only allows SVGs through upload paths it can actively sanitize. While most WordPress uploads use standard functions like `wp_handle_upload()` (which Safe SVG hooks), plugins and themes can create custom upload paths by calling WordPress's underlying `_wp_handle_upload()` function with arbitrary action parameters.

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -349,6 +349,22 @@ if ( ! class_exists( 'SafeSvg\\safe_svg' ) ) {
 			}
 
 			/**
+			 * Strip references to remote resources from the SVG.
+			 *
+			 * This removes remote `href`/`xlink:href` targets, along with `url()`,
+			 * `@import` and `image-set()` references inside `<style>` elements and
+			 * `style` attributes.
+			 *
+			 * It is off by default as some SVGs reference remote fonts and images,
+			 * and removing them would silently change how those files render.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param bool $remove_remote_references Whether to strip remote references. Default false.
+			 */
+			$this->sanitizer->removeRemoteReferences( (bool) apply_filters( 'safe_svg_remove_remote_references', false ) );
+
+			/**
 			 * Load extra filters to allow devs to access the safe tags and attrs by themselves.
 			 */
 			$this->sanitizer->setAllowedTags( new SafeSvgTags\safe_svg_tags() );

--- a/tests/bin/initialize.sh
+++ b/tests/bin/initialize.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 wp-env run tests-wordpress chmod -c ugo+w /var/www/html
 wp-env run tests-cli wp rewrite structure '/%postname%/' --hard
+
+# Turn off the block editor welcome guide.
+wp-env run tests-cli wp user meta update admin wp_persisted_preferences '{"core/edit-post":{"welcomeGuide":false},"core/edit-site":{"welcomeGuide":false,"welcomeGuideStyles":false}}' --format=json

--- a/tests/cypress/e2e/svg-inline-isolation.cy.js
+++ b/tests/cypress/e2e/svg-inline-isolation.cy.js
@@ -1,0 +1,160 @@
+/**
+ * A `<style>` element inside an inline SVG is not scoped to the SVG: the browser
+ * applies its rules to the whole document. The Inline SVG block therefore renders
+ * SVGs that carry a stylesheet inside a shadow root, which the browser does scope,
+ * and wraps the shadow host in an element with paint containment, so that CSS in
+ * the shadow root can't reposition its own host over the page either.
+ *
+ * These tests use tests/cypress/fixtures/hostileStyle.svg, which tries both.
+ *
+ * Note on the file name: Cypress runs specs alphabetically, and
+ * tests/cypress/test-plugin/e2e-test-plugin.php refers to attachment ID 6, so the
+ * assertions at the end of safe-svg.cy.js depend on how many files earlier specs
+ * uploaded. This spec uploads media, so it has to sort after safe-svg.cy.js.
+ */
+describe( 'Inline SVG CSS isolation', () => {
+	beforeEach( () => {
+		cy.login();
+
+		// Plugin activation persists between runs, and the SVGO optimizer rewrites
+		// the CSS inside an SVG (dropping rules whose selectors match nothing within
+		// it). Pin both test plugins off so these tests exercise the default setup.
+		cy.deactivatePlugin( 'safe-svg-cypress-test-plugin' );
+		cy.deactivatePlugin( 'safe-svg-cypress-optimizer-test-plugin' );
+	} );
+
+	/**
+	 * Publish a post containing the Inline SVG block, pointed at the most recently
+	 * uploaded SVG.
+	 *
+	 * @param {string} title Post title.
+	 * @return {Cypress.Chainable} Wraps the created post.
+	 */
+	const publishPostWithBlock = ( title ) =>
+		cy.createPost( {
+			title,
+			beforeSave: () => {
+				cy.insertBlock( 'safe-svg/svg-icon' );
+				cy.getBlockEditor()
+					.find( '.block-editor-media-placeholder' )
+					.contains( 'button', 'Media Library' )
+					.click();
+				cy.get( '#menu-item-browse' ).click();
+				cy.get( '.attachments-wrapper li:first .thumbnail' ).click();
+				cy.get( '.media-modal .media-button-select' ).click();
+			},
+		} );
+
+	it( 'SVG CSS does not escape the block', () => {
+		cy.uploadMedia( 'tests/cypress/fixtures/hostileStyle.svg' );
+
+		publishPostWithBlock( 'Inline SVG isolation' ).then( ( post ) => {
+			// The CSS is still served. It is isolated, not stripped, so this is what
+			// proves the isolation is doing the work rather than the sanitizer.
+			cy.request( `/?p=${ post.id }` )
+				.its( 'body' )
+				.should( 'contain', 'safe-svg-css-leak-probe' );
+
+			cy.visit( `/?p=${ post.id }` );
+
+			// The page is intact: the title is still rendered, so `body *
+			// { display: none }` did not leak out of the SVG.
+			cy.contains( 'Inline SVG isolation' ).should( 'be.visible' );
+
+			cy.document().then( ( doc ) => {
+				const win = doc.defaultView;
+
+				expect(
+					win.getComputedStyle( doc.body ).backgroundColor,
+					'body background'
+				).to.not.equal( 'rgb(1, 2, 3)' );
+				expect(
+					win.getComputedStyle( doc.body, '::before' ).content,
+					'injected body::before'
+				).to.not.contain( 'SAFE-SVG-CSS-LEAK' );
+			} );
+		} );
+	} );
+
+	it( 'SVG renders inside a shadow root', () => {
+		cy.uploadMedia( 'tests/cypress/fixtures/hostileStyle.svg' );
+
+		publishPostWithBlock( 'Inline SVG shadow root' ).then( ( post ) => {
+			cy.visit( `/?p=${ post.id }` );
+
+			cy.get( '.safe-svg-shadow-host' ).should( ( $host ) => {
+				const host = $host[ 0 ];
+
+				expect( host.shadowRoot, 'shadow root' ).to.not.equal( null );
+				expect(
+					host.shadowRoot.querySelector( 'svg' ),
+					'SVG inside the shadow root'
+				).to.not.equal( null );
+
+				// Nothing is left in the light DOM to leak.
+				expect(
+					host.querySelector( 'template' ),
+					'leftover template'
+				).to.equal( null );
+				expect(
+					host.querySelector( 'svg' ),
+					'SVG in the light DOM'
+				).to.equal( null );
+			} );
+
+			cy.get( '.safe-svg-shadow-guard' )
+				.should( 'have.attr', 'style' )
+				.and( 'contain', 'contain: paint' );
+		} );
+	} );
+
+	it( 'SVG cannot paint outside the space the block gave it', () => {
+		cy.uploadMedia( 'tests/cypress/fixtures/hostileStyle.svg' );
+
+		publishPostWithBlock( 'Inline SVG containment' ).then( ( post ) => {
+			cy.visit( `/?p=${ post.id }` );
+
+			cy.document().then( ( doc ) => {
+				const win = doc.defaultView;
+				const host = doc.querySelector( '.safe-svg-shadow-host' );
+				const guard = doc.querySelector( '.safe-svg-shadow-guard' );
+				const box = guard.getBoundingClientRect();
+
+				// The host's layout box covers the viewport, because `:host` gave it
+				// `position: fixed`. Paint containment on the guard means none of it is
+				// actually drawn beyond the space the block gave the SVG.
+				const hits = [];
+				for ( let y = 0; y < win.innerHeight; y += 8 ) {
+					for ( let x = 0; x < win.innerWidth; x += 8 ) {
+						if ( doc.elementFromPoint( x, y ) === host ) {
+							hits.push( [ x, y ] );
+						}
+					}
+				}
+
+				hits.forEach( ( [ x, y ] ) => {
+					expect(
+						x >= Math.floor( box.left ) &&
+							x <= Math.ceil( box.right ) &&
+							y >= Math.floor( box.top ) &&
+							y <= Math.ceil( box.bottom ),
+						`paint at ${ x },${ y } is inside the guard`
+					).to.equal( true );
+				} );
+			} );
+		} );
+	} );
+
+	it( 'SVG without a stylesheet is left in the light DOM', () => {
+		cy.uploadMedia( 'tests/cypress/fixtures/custom.svg' );
+
+		publishPostWithBlock( 'Inline SVG no stylesheet' ).then( ( post ) => {
+			cy.visit( `/?p=${ post.id }` );
+
+			// Nothing to isolate, so nothing changes: themes can still style the SVG.
+			cy.get( '.wp-block-safe-svg-svg-icon svg' ).should( 'exist' );
+			cy.get( '.safe-svg-shadow-host' ).should( 'not.exist' );
+			cy.get( '.safe-svg-shadow-guard' ).should( 'not.exist' );
+		} );
+	} );
+} );

--- a/tests/cypress/e2e/svg-inline-isolation.cy.js
+++ b/tests/cypress/e2e/svg-inline-isolation.cy.js
@@ -7,6 +7,11 @@
  *
  * These tests use tests/cypress/fixtures/hostileStyle.svg, which tries both.
  *
+ * The post is created through the REST API rather than the block editor UI. These
+ * tests are about what the block renders on the front end, not how it is inserted,
+ * and driving the editor's inserter couples them to Gutenberg markup that shifts
+ * between WordPress versions.
+ *
  * Note on the file name: Cypress runs specs alphabetically, and
  * tests/cypress/test-plugin/e2e-test-plugin.php refers to attachment ID 6, so the
  * assertions at the end of safe-svg.cy.js depend on how many files earlier specs
@@ -24,31 +29,38 @@ describe( 'Inline SVG CSS isolation', () => {
 	} );
 
 	/**
-	 * Publish a post containing the Inline SVG block, pointed at the most recently
-	 * uploaded SVG.
+	 * Upload an SVG and publish a post containing the Inline SVG block for it.
 	 *
-	 * @param {string} title Post title.
-	 * @return {Cypress.Chainable} Wraps the created post.
+	 * @param {string} title   Post title.
+	 * @param {string} fixture Path to the SVG fixture to upload.
+	 * @return {Cypress.Chainable} Wraps the created post (REST response body).
 	 */
-	const publishPostWithBlock = ( title ) =>
-		cy.createPost( {
-			title,
-			beforeSave: () => {
-				cy.insertBlock( 'safe-svg/svg-icon' );
-				cy.getBlockEditor()
-					.find( '.block-editor-media-placeholder' )
-					.contains( 'button', 'Media Library' )
-					.click();
-				cy.get( '#menu-item-browse' ).click();
-				cy.get( '.attachments-wrapper li:first .thumbnail' ).click();
-				cy.get( '.media-modal .media-button-select' ).click();
-			},
-		} );
+	const publishPostWithBlock = ( title, fixture ) =>
+		cy.uploadMediaThroughGrid( fixture ).then( ( attachmentId ) =>
+			// A REST request needs the cookie nonce; admin-ajax hands one out.
+			cy
+				.request( '/wp-admin/admin-ajax.php?action=rest-nonce' )
+				.then( ( nonceResponse ) =>
+					cy
+						.request( {
+							method: 'POST',
+							url: '/wp-json/wp/v2/posts',
+							headers: { 'X-WP-Nonce': nonceResponse.body },
+							body: {
+								title,
+								status: 'publish',
+								content: `<!-- wp:safe-svg/svg-icon {"imageID":${ attachmentId },"dimensionWidth":120,"dimensionHeight":120} /-->`,
+							},
+						} )
+						.then( ( postResponse ) => postResponse.body )
+				)
+		);
 
 	it( 'SVG CSS does not escape the block', () => {
-		cy.uploadMedia( 'tests/cypress/fixtures/hostileStyle.svg' );
-
-		publishPostWithBlock( 'Inline SVG isolation' ).then( ( post ) => {
+		publishPostWithBlock(
+			'Inline SVG isolation',
+			'tests/cypress/fixtures/hostileStyle.svg'
+		).then( ( post ) => {
 			// The CSS is still served. It is isolated, not stripped, so this is what
 			// proves the isolation is doing the work rather than the sanitizer.
 			cy.request( `/?p=${ post.id }` )
@@ -77,9 +89,10 @@ describe( 'Inline SVG CSS isolation', () => {
 	} );
 
 	it( 'SVG renders inside a shadow root', () => {
-		cy.uploadMedia( 'tests/cypress/fixtures/hostileStyle.svg' );
-
-		publishPostWithBlock( 'Inline SVG shadow root' ).then( ( post ) => {
+		publishPostWithBlock(
+			'Inline SVG shadow root',
+			'tests/cypress/fixtures/hostileStyle.svg'
+		).then( ( post ) => {
 			cy.visit( `/?p=${ post.id }` );
 
 			cy.get( '.safe-svg-shadow-host' ).should( ( $host ) => {
@@ -109,9 +122,10 @@ describe( 'Inline SVG CSS isolation', () => {
 	} );
 
 	it( 'SVG cannot paint outside the space the block gave it', () => {
-		cy.uploadMedia( 'tests/cypress/fixtures/hostileStyle.svg' );
-
-		publishPostWithBlock( 'Inline SVG containment' ).then( ( post ) => {
+		publishPostWithBlock(
+			'Inline SVG containment',
+			'tests/cypress/fixtures/hostileStyle.svg'
+		).then( ( post ) => {
 			cy.visit( `/?p=${ post.id }` );
 
 			cy.document().then( ( doc ) => {
@@ -146,9 +160,10 @@ describe( 'Inline SVG CSS isolation', () => {
 	} );
 
 	it( 'SVG without a stylesheet is left in the light DOM', () => {
-		cy.uploadMedia( 'tests/cypress/fixtures/custom.svg' );
-
-		publishPostWithBlock( 'Inline SVG no stylesheet' ).then( ( post ) => {
+		publishPostWithBlock(
+			'Inline SVG no stylesheet',
+			'tests/cypress/fixtures/custom.svg'
+		).then( ( post ) => {
 			cy.visit( `/?p=${ post.id }` );
 
 			// Nothing to isolate, so nothing changes: themes can still style the SVG.

--- a/tests/cypress/fixtures/hostileStyle.svg
+++ b/tests/cypress/fixtures/hostileStyle.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+	<style>
+		/* safe-svg-css-leak-probe: these rules must not reach the page. */
+		body { background: rgb(1, 2, 3) !important; }
+		body * { display: none !important; }
+		body::before {
+			content: "SAFE-SVG-CSS-LEAK";
+			position: fixed; top: 50%; left: 50%;
+			color: #fff; font-size: 32px; z-index: 99999;
+			display: block !important;
+		}
+
+		/* Styling its own host is the one thing CSS in a shadow root can still do. */
+		:host {
+			position: fixed !important; top: 0 !important; left: 0 !important;
+			width: 100vw !important; height: 100vh !important;
+			z-index: 2147483647 !important; background: rgb(1, 2, 3) !important;
+			contain: none !important; display: block !important;
+		}
+	</style>
+	<rect width="120" height="120" fill="rgb(1,2,3)"/>
+</svg>

--- a/tests/unit/files/svgHostileStyle.svg
+++ b/tests/unit/files/svgHostileStyle.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+	<style>
+		/* Leak into the parent document: hide the page and overlay our own text. */
+		body { background: #020000 !important; }
+		body * { display: none !important; }
+		body::before {
+			content: "DEFACED";
+			position: fixed; top: 50%; left: 50%;
+			color: #fff; font-size: 32px; z-index: 99999;
+			display: block !important;
+		}
+		#safe-svg-probe { display: none !important; visibility: hidden !important; }
+
+		/* Escape the shadow root by repositioning our own host over the page. */
+		:host {
+			position: fixed !important; top: 0 !important; left: 0 !important;
+			width: 100vw !important; height: 100vh !important;
+			z-index: 2147483647 !important; background: rgb(3,3,3) !important;
+			contain: none !important;
+			display: block !important;
+		}
+		:host-context(body) { background: rgb(3,3,3) !important; }
+	</style>
+	<rect width="120" height="120" fill="rgb(3,3,3)"/>
+	<text x="6" y="64" fill="#ffffff" font-size="16">ESCAPED</text>
+</svg>

--- a/tests/unit/files/svgWithStyle.svg
+++ b/tests/unit/files/svgWithStyle.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120">
+	<style>
+		.ring { fill: none; stroke: currentColor; stroke-width: 8; }
+		.dot { fill: #2f7d4f; }
+	</style>
+	<circle class="ring" cx="60" cy="60" r="48"/>
+	<circle class="dot" cx="60" cy="60" r="18"/>
+</svg>

--- a/tests/unit/test-safe-svg-block.php
+++ b/tests/unit/test-safe-svg-block.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Test the Safe SVG block render callback
+ *
+ * @package safe-svg
+ */
+
+use \WP_Mock\Tools\TestCase;
+use SafeSvg\Blocks\SafeSvgBlock as Block;
+
+require_once TEST_PLUGIN_DIR . '/includes/blocks/safe-svg/register.php';
+
+/**
+ * SafeSvgBlockTest tests the block's server side rendering.
+ */
+class SafeSvgBlockTest extends TestCase {
+	/**
+	 * Set up WP Mock.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		\WP_Mock::setUp();
+	}
+
+	/**
+	 * Tear down WP Mock.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	/**
+	 * Read one of the SVG fixtures.
+	 *
+	 * WP_Mock matches filter arguments by exact value, so a mock for a filter that
+	 * receives the SVG contents has to be given the same string.
+	 *
+	 * @param string $fixture File name within tests/unit/files.
+	 *
+	 * @return string The file contents.
+	 */
+	protected function fixture( $fixture ) {
+		return file_get_contents( TEST_PLUGIN_DIR . '/tests/unit/files/' . $fixture ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	}
+
+	/**
+	 * Render the block for one of the SVG fixtures.
+	 *
+	 * @param string $fixture    File name within tests/unit/files.
+	 * @param array  $attributes Block attributes to merge in.
+	 *
+	 * @return string The rendered block markup.
+	 */
+	protected function render( $fixture, $attributes = array() ) {
+		\WP_Mock::userFunction(
+			'get_post_mime_type',
+			array( 'return' => 'image/svg+xml' )
+		);
+		\WP_Mock::userFunction(
+			'get_attached_file',
+			array( 'return' => TEST_PLUGIN_DIR . '/tests/unit/files/' . $fixture )
+		);
+		\WP_Mock::passthruFunction( 'esc_attr' );
+		\WP_Mock::passthruFunction( 'esc_url' );
+
+		return Block\render_block_callback(
+			array_merge(
+				array(
+					'imageID'         => 1,
+					'alignment'       => 'left',
+					'dimensionWidth'  => 120,
+					'dimensionHeight' => 120,
+				),
+				$attributes
+			)
+		);
+	}
+
+	/**
+	 * Test that SVGs carrying a stylesheet are recognised.
+	 */
+	public function test_svg_has_stylesheet() {
+		$this->assertTrue( Block\svg_has_stylesheet( '<svg><style>a{fill:red}</style></svg>' ) );
+		$this->assertTrue( Block\svg_has_stylesheet( '<svg><style type="text/css">a{fill:red}</style></svg>' ) );
+		$this->assertTrue( Block\svg_has_stylesheet( '<svg><defs><style>a{fill:red}</style></defs></svg>' ) );
+
+		// The HTML parser lower-cases tag names and resolves prefixes, so both of
+		// these become a style element once the SVG is inlined into the page.
+		$this->assertTrue( Block\svg_has_stylesheet( '<svg><STYLE>a{fill:red}</STYLE></svg>' ) );
+		$this->assertTrue( Block\svg_has_stylesheet( '<svg><svg:style>a{fill:red}</svg:style></svg>' ) );
+
+		// A self closing element still declares a stylesheet.
+		$this->assertTrue( Block\svg_has_stylesheet( '<svg><style/></svg>' ) );
+	}
+
+	/**
+	 * Test that SVGs without a stylesheet are left alone.
+	 */
+	public function test_svg_has_no_stylesheet() {
+		$this->assertFalse( Block\svg_has_stylesheet( '<svg><rect fill="red"/></svg>' ) );
+
+		// A style attribute only ever applies to the element it sits on.
+		$this->assertFalse( Block\svg_has_stylesheet( '<svg style="fill:red"><rect style="fill:red"/></svg>' ) );
+
+		// Escaped markup in a text node is inert.
+		$this->assertFalse( Block\svg_has_stylesheet( '<svg><text>&lt;style&gt;</text></svg>' ) );
+
+		// Elements that merely start with the same letters are not style elements.
+		$this->assertFalse( Block\svg_has_stylesheet( '<svg><styles>a{fill:red}</styles></svg>' ) );
+	}
+
+	/**
+	 * Test that an SVG with a stylesheet is isolated in a shadow root.
+	 */
+	public function test_svg_with_stylesheet_is_isolated() {
+		$markup = $this->render( 'svgWithStyle.svg' );
+
+		$this->assertStringContainsString( '<span class="safe-svg-shadow-host"', $markup );
+		$this->assertStringContainsString( '<template shadowrootmode="open">', $markup );
+		$this->assertStringContainsString( '</template>', $markup );
+
+		// The SVG has to sit inside the template to be scoped by it.
+		$this->assertMatchesRegularExpression( '#<template shadowrootmode="open">.*<svg#s', $markup );
+
+		// Paint containment on a guard wrapping the host stops CSS in the shadow root
+		// repositioning its own host over the rest of the page.
+		$this->assertMatchesRegularExpression(
+			'#<span class="safe-svg-shadow-guard" style="[^"]*contain: paint;[^"]*"><span class="safe-svg-shadow-host"#',
+			$markup
+		);
+	}
+
+	/**
+	 * Test the reported case: an SVG whose CSS targets the page around it.
+	 *
+	 * The CSS is deliberately kept rather than stripped, so this asserts that every
+	 * page-targeting rule ends up inside the template, where the browser scopes it,
+	 * and that nothing is left in the light DOM to apply to the document.
+	 */
+	public function test_page_targeting_css_is_confined_to_the_shadow_root() {
+		$markup = $this->render( 'svgHostileStyle.svg' );
+
+		preg_match( '#<template shadowrootmode="open">(.*)</template>#s', $markup, $matches );
+		$this->assertNotEmpty( $matches, 'the SVG is rendered inside a template' );
+
+		$in_shadow_root = $matches[1];
+		$light_dom      = str_replace( $matches[0], '', $markup );
+
+		foreach ( array( 'body {', 'body *', 'body::before', ':host' ) as $rule ) {
+			$this->assertStringContainsString( $rule, $in_shadow_root, "$rule is inside the shadow root" );
+			$this->assertStringNotContainsString( $rule, $light_dom, "$rule is not in the light DOM" );
+		}
+
+		// Paint containment covers the one thing shadow CSS can still reach: its host.
+		$this->assertStringContainsString( 'contain: paint;', $light_dom );
+	}
+
+	/**
+	 * Test that an SVG without a stylesheet is rendered as it always was.
+	 */
+	public function test_svg_without_stylesheet_is_not_isolated() {
+		$markup = $this->render( 'svgCleanOne.svg' );
+
+		$this->assertStringNotContainsString( 'safe-svg-shadow-host', $markup );
+		$this->assertStringNotContainsString( 'shadowrootmode', $markup );
+		$this->assertStringNotContainsString( 'contain: paint;', $markup );
+		$this->assertStringContainsString( '<svg', $markup );
+	}
+
+	/**
+	 * Test that the shadow root carries the styles the block stylesheet can't reach in with.
+	 */
+	public function test_shadow_root_includes_block_styles() {
+		$markup = $this->render( 'svgWithStyle.svg' );
+
+		$this->assertMatchesRegularExpression(
+			'#<template shadowrootmode="open"><style>svg\{[^}]*fill:currentColor[^}]*\}</style>#',
+			$markup
+		);
+	}
+
+	/**
+	 * Test that the link stays in the light DOM, outside the shadow root.
+	 *
+	 * Markup inside a shadow root is not visible to every crawler, and the link is
+	 * generated by the block rather than supplied by the SVG, so it gains nothing
+	 * from being isolated.
+	 */
+	public function test_link_is_outside_the_shadow_root() {
+		$markup = $this->render(
+			'svgWithStyle.svg',
+			array(
+				'href'      => 'https://example.com',
+				'linkLabel' => 'Example',
+			)
+		);
+
+		$this->assertMatchesRegularExpression(
+			'#<a href="https://example.com"[^>]*><span class="safe-svg-shadow-guard"#',
+			$markup
+		);
+		$this->assertStringNotContainsString( '<template shadowrootmode="open"><a', $markup );
+	}
+
+	/**
+	 * Test that a closing template tag in the SVG can't end the shadow root early.
+	 *
+	 * The sanitizer escapes text on save so this can't happen to a file it has
+	 * processed, but files predating the plugin, or changed on disk since, have not
+	 * necessarily been through it.
+	 */
+	public function test_closing_template_tag_is_neutralised() {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg"><style>/* </template><style>body{display:none}</style> */</style></svg>';
+
+		$markup = Block\wrap_in_shadow_root( $svg, 1 );
+
+		// Exactly one closing tag: the one that ends the shadow root.
+		$this->assertSame( 1, substr_count( strtolower( $markup ), '</template>' ) );
+		$this->assertStringContainsString( '&lt;/template>', $markup );
+	}
+
+	/**
+	 * Test that the shadow styles can't break out of their own style element.
+	 */
+	public function test_shadow_styles_cannot_close_their_element() {
+		\WP_Mock::onFilter( 'safe_svg_inline_shadow_styles' )
+			->with( 'svg{fill:currentColor;width:100%;height:100%;max-width:100%;max-height:100%}', 1 )
+			->reply( 'svg{fill:red}</style><style>body{display:none}' );
+
+		$markup = Block\wrap_in_shadow_root( '<svg xmlns="http://www.w3.org/2000/svg"></svg>', 1 );
+
+		// One style element, the one holding the filtered CSS. What the filter tried
+		// to smuggle in survives as inert text rather than markup.
+		$this->assertSame( 1, substr_count( $markup, '<style>' ) );
+		$this->assertSame( 1, substr_count( $markup, '</style>' ) );
+
+		preg_match( '#<style>(.*?)</style>#s', $markup, $matches );
+		$this->assertStringNotContainsString( '<', $matches[1] );
+	}
+
+	/**
+	 * Test that isolation can be turned off for a site that styles SVGs from its theme.
+	 */
+	public function test_isolation_can_be_filtered_off() {
+		\WP_Mock::onFilter( 'safe_svg_inline_use_shadow_dom' )
+			->with( true, $this->fixture( 'svgWithStyle.svg' ), 1 )
+			->reply( false );
+
+		$markup = $this->render( 'svgWithStyle.svg' );
+
+		$this->assertStringNotContainsString( 'shadowrootmode', $markup );
+		$this->assertStringNotContainsString( 'contain: paint;', $markup );
+	}
+
+	/**
+	 * Test that isolation can be forced on for every SVG.
+	 */
+	public function test_isolation_can_be_filtered_on() {
+		\WP_Mock::onFilter( 'safe_svg_inline_use_shadow_dom' )
+			->with( false, $this->fixture( 'svgCleanOne.svg' ), 1 )
+			->reply( true );
+
+		$markup = $this->render( 'svgCleanOne.svg' );
+
+		$this->assertStringContainsString( 'shadowrootmode', $markup );
+		$this->assertStringContainsString( 'contain: paint;', $markup );
+	}
+
+	/**
+	 * Test that a non SVG attachment renders nothing.
+	 */
+	public function test_non_svg_renders_nothing() {
+		\WP_Mock::userFunction(
+			'get_post_mime_type',
+			array( 'return' => 'image/png' )
+		);
+
+		$this->assertSame( '', Block\render_block_callback( array( 'imageID' => 1 ) ) );
+	}
+}

--- a/tests/unit/test-safe-svg-block.php
+++ b/tests/unit/test-safe-svg-block.php
@@ -81,35 +81,65 @@ class SafeSvgBlockTest extends TestCase {
 
 	/**
 	 * Test that SVGs carrying a stylesheet are recognised.
+	 *
+	 * @dataProvider data_svg_has_stylesheet
+	 *
+	 * @param string $svg SVG markup declaring a stylesheet.
 	 */
-	public function test_svg_has_stylesheet() {
-		$this->assertTrue( Block\svg_has_stylesheet( '<svg><style>a{fill:red}</style></svg>' ) );
-		$this->assertTrue( Block\svg_has_stylesheet( '<svg><style type="text/css">a{fill:red}</style></svg>' ) );
-		$this->assertTrue( Block\svg_has_stylesheet( '<svg><defs><style>a{fill:red}</style></defs></svg>' ) );
+	public function test_svg_has_stylesheet( $svg ) {
+		$this->assertTrue( Block\svg_has_stylesheet( $svg ) );
+	}
 
-		// The HTML parser lower-cases tag names and resolves prefixes, so both of
-		// these become a style element once the SVG is inlined into the page.
-		$this->assertTrue( Block\svg_has_stylesheet( '<svg><STYLE>a{fill:red}</STYLE></svg>' ) );
-		$this->assertTrue( Block\svg_has_stylesheet( '<svg><svg:style>a{fill:red}</svg:style></svg>' ) );
+	/**
+	 * Data provider for test_svg_has_stylesheet.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public static function data_svg_has_stylesheet() {
+		return array(
+			'style element'              => array( '<svg><style>a{fill:red}</style></svg>' ),
+			'style element with a type'  => array( '<svg><style type="text/css">a{fill:red}</style></svg>' ),
+			'style element within defs'  => array( '<svg><defs><style>a{fill:red}</style></defs></svg>' ),
 
-		// A self closing element still declares a stylesheet.
-		$this->assertTrue( Block\svg_has_stylesheet( '<svg><style/></svg>' ) );
+			// The HTML parser lower-cases tag names and resolves prefixes, so both of
+			// these become a style element once the SVG is inlined into the page.
+			'upper case style element'   => array( '<svg><STYLE>a{fill:red}</STYLE></svg>' ),
+			'prefixed style element'     => array( '<svg><svg:style>a{fill:red}</svg:style></svg>' ),
+
+			// A self closing element still declares a stylesheet.
+			'self closing style element' => array( '<svg><style/></svg>' ),
+		);
 	}
 
 	/**
 	 * Test that SVGs without a stylesheet are left alone.
+	 *
+	 * @dataProvider data_svg_has_no_stylesheet
+	 *
+	 * @param string $svg SVG markup declaring no stylesheet.
 	 */
-	public function test_svg_has_no_stylesheet() {
-		$this->assertFalse( Block\svg_has_stylesheet( '<svg><rect fill="red"/></svg>' ) );
+	public function test_svg_has_no_stylesheet( $svg ) {
+		$this->assertFalse( Block\svg_has_stylesheet( $svg ) );
+	}
 
-		// A style attribute only ever applies to the element it sits on.
-		$this->assertFalse( Block\svg_has_stylesheet( '<svg style="fill:red"><rect style="fill:red"/></svg>' ) );
+	/**
+	 * Data provider for test_svg_has_no_stylesheet.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public static function data_svg_has_no_stylesheet() {
+		return array(
+			'no stylesheet'          => array( '<svg><rect fill="red"/></svg>' ),
 
-		// Escaped markup in a text node is inert.
-		$this->assertFalse( Block\svg_has_stylesheet( '<svg><text>&lt;style&gt;</text></svg>' ) );
+			// A style attribute only ever applies to the element it sits on.
+			'style attributes'       => array( '<svg style="fill:red"><rect style="fill:red"/></svg>' ),
 
-		// Elements that merely start with the same letters are not style elements.
-		$this->assertFalse( Block\svg_has_stylesheet( '<svg><styles>a{fill:red}</styles></svg>' ) );
+			// Escaped markup in a text node is inert.
+			'escaped style element'  => array( '<svg><text>&lt;style&gt;</text></svg>' ),
+
+			// Elements that merely start with the same letters are not style elements.
+			'element named styles'   => array( '<svg><styles>a{fill:red}</styles></svg>' ),
+		);
 	}
 
 	/**
@@ -246,7 +276,7 @@ class SafeSvgBlockTest extends TestCase {
 	 */
 	public function test_isolation_can_be_filtered_off() {
 		\WP_Mock::onFilter( 'safe_svg_inline_use_shadow_dom' )
-			->with( true, $this->fixture( 'svgWithStyle.svg' ), 1 )
+			->with( true, $this->fixture( 'svgWithStyle.svg' ), 1, true )
 			->reply( false );
 
 		$markup = $this->render( 'svgWithStyle.svg' );
@@ -260,7 +290,7 @@ class SafeSvgBlockTest extends TestCase {
 	 */
 	public function test_isolation_can_be_filtered_on() {
 		\WP_Mock::onFilter( 'safe_svg_inline_use_shadow_dom' )
-			->with( false, $this->fixture( 'svgCleanOne.svg' ), 1 )
+			->with( false, $this->fixture( 'svgCleanOne.svg' ), 1, false )
 			->reply( true );
 
 		$markup = $this->render( 'svgCleanOne.svg' );


### PR DESCRIPTION
### Description of the Change

When rendering an SVG in our SVG block, we don't strip out any styles. This can result in someone adding styles that impact other areas of the page and by rendering the SVG, they can impact how the rest of the page looks.

To address this, this PR introduces new handling within the SVG block for any SVG that comes with it's own styles, wrapping those SVGs in a shadow DOM which keeps the styles isolated. This only applies to SVGs that come with styles (though can be turned on/off using the new `safe_svg_inline_use_shadow_dom` filter) so for majority of use cases, this won't change anything.

Note though for SVGs that do ship with their own styles, theme CSS will no longer be able to target them because of this shadow DOM. That styling will need to be done from within the SVG itself or you can opt out using the `safe_svg_inline_use_shadow_dom` filter.

In addition, replace the use of `ReactSVG` with our own custom `InlineSvg` component that will offer the same protections within the block editor.

We've also introduced the new `removeRemoteReferences` property of the sanitizer (coming in v1.0.0) and set that to false by default. This can be turned on with the new `safe_svg_remove_remote_references` filter, which will then strip out any remote references, making the SVG markup even more secure.

### How to test the Change

**NOTE**: The code here is dependent on the update in https://github.com/10up/safe-svg/pull/327 so that will either need merged first before testing this or you'll need to manually pull that change in locally when testing.

Basic testing across the plugin is desired here to ensure these changes don't break any existing functionality. Main thing to test is the SVG block.

Beyond that, the automated tests this PR ships with contains some SVG files you can use for testing to ensure the styles they load don't leak into the main document.

### Changelog Entry

> Added - New `safe_svg_remove_remote_references` filter to strip remote `url()`, `@import` and `image-set()` references, along with remote `href` targets, from uploaded SVGs. Off by default, because legitimate SVGs reference remote fonts and images but use this filter to turn it on

> Added - New `safe_svg_inline_use_shadow_dom` filter to control which inline SVGs are isolated in a shadow root, and new `safe_svg_inline_shadow_styles` filter to adjust the CSS injected alongside them

> Changed - Theme CSS can no longer target an inline SVG that carries its own `<style>` element, because stylesheets cannot reach into a shadow root. Style those SVGs from within the SVG itself, or opt out with the `safe_svg_inline_use_shadow_dom` filter. Inherited properties, including `color`/`currentColor` and custom properties, still apply as before, and SVGs without a `<style>` element are unaffected

> Security - The Inline SVG block now renders SVGs that carry their own `<style>` element inside a shadow root, so their CSS is scoped to the block instead of applying to the whole page

> Developer - Replaced the `react-svg` dependency with a small internal component, so the block editor preview isolates SVG CSS the same way the front end does

### Credits

Props @darylldoyle, @dkotter 

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
