### PR TITLE
Add consistent version checks

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -53,3 +53,25 @@ jobs:
 
     - name: PHPUnit
       run: './vendor/bin/phpunit'
+
+  consistent-versions:
+    name: Consistent Versions
+    runs-on: ubuntu-latest
+    needs: phpunit
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Set PHP version
+      uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+      with:
+        php-version: '8.1'
+        coverage: none
+        tools: composer:v2
+
+    - name: Install consistent-versions
+      run: composer create-project --no-interaction --no-progress szepeviktor/consistent-versions consistent-versions
+
+    - name: Check versions
+      run: php consistent-versions/bin/consistent-versions check

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ WordPress’s `_wp_handle_upload( $file, $action )` function allows any `$action
 ## Requirements
 
 * PHP 7.4+
-* [WordPress](http://wordpress.org/) 6.6+
+* [WordPress](http://wordpress.org/) 6.9+
 
 ## Installation
 

--- a/consistent-versions.yaml
+++ b/consistent-versions.yaml
@@ -1,0 +1,58 @@
+checks:
+  plugin-version:
+    normalize: version
+    expected:
+      reader: wordpress-plugin
+      file: safe-svg.php
+      path: $.Version
+    values:
+      php-constant:
+        reader: php
+        file: safe-svg.php
+        path: $.constants.SAFE_SVG_VERSION
+      wordpress-readme:
+        reader: wordpress-readme
+        file: readme.txt
+        path: $['Stable tag']
+      package-json:
+        reader: json
+        file: package.json
+        path: $.version
+      package-lock:
+        reader: json
+        file: package-lock.json
+        path: $.version
+      package-lock-root:
+        reader: json
+        file: package-lock.json
+        path: $.packages[''].version
+
+  minimum-php:
+    normalize: version
+    expected:
+      reader: composer
+      file: composer.json
+      path: $.require.php
+      normalize: composer-minimum
+    values:
+      php-constant:
+        reader: php
+        file: safe-svg.php
+        path: $.constants.SAFE_SVG_MINIMUM_PHP
+      wordpress-readme:
+        reader: wordpress-readme
+        file: readme.txt
+        path: $['Requires PHP']
+
+  minimum-wordpress:
+    normalize: version
+    expected:
+      reader: wordpress-readme
+      file: readme.txt
+      path: $['Requires at least']
+    values:
+      cypress-workflow:
+        reader: yaml
+        file: .github/workflows/cypress.yml
+        path: $.jobs.cypress.strategy.matrix.core[?@.name == "WP minimum"].version
+        normalize: wp-env-core

--- a/safe-svg.php
+++ b/safe-svg.php
@@ -25,6 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'SAFE_SVG_VERSION', '2.5.0' );
+define( 'SAFE_SVG_MINIMUM_PHP', '7.4' );
 define( 'SAFE_SVG_PLUGIN_DIR', __DIR__ );
 define( 'SAFE_SVG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -36,7 +37,7 @@ define( 'SAFE_SVG_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
  * @return string Minimum version required.
  */
 function minimum_php_requirement() {
-	return '7.4';
+	return SAFE_SVG_MINIMUM_PHP;
 }
 
 /**

--- a/tests/unit/test-plugin-headers.php
+++ b/tests/unit/test-plugin-headers.php
@@ -359,9 +359,6 @@ class PluginHeadersTests extends TestCase {
 		);
 
 		$headers = array();
-		// Always test the version matches the stable tag.
-		$headers['Stable tag matches version'] = array( 'Version', 'Stable tag' );
-
 		foreach ( $common_headers as $header => $value ) {
 			$headers[ $header ] = array( $header );
 		}
@@ -405,66 +402,6 @@ class PluginHeadersTests extends TestCase {
 		}
 
 		return $tests;
-	}
-
-	/**
-	 * Test minimum PHP requirement matches across composer.json, readme.txt,
-	 * and minimum_php_requirement() in the plugin file.
-	 */
-	public function test_minimum_php_requirement_matches_across_files() {
-		$composer_file = self::PLUGIN_ROOT_DIR . '/composer.json';
-		$plugin_file   = self::$file_names['plugin'];
-
-		$composer_contents = file_get_contents( $composer_file );
-		$this->assertNotFalse( $composer_contents, 'Unable to read composer.json.' );
-
-		$composer_data = json_decode( $composer_contents, true );
-		$this->assertIsArray( $composer_data, 'composer.json is not valid JSON.' );
-		$this->assertArrayHasKey( 'require', $composer_data, 'composer.json is missing the require section.' );
-		$this->assertArrayHasKey( 'php', $composer_data['require'], 'composer.json is missing require.php.' );
-
-		preg_match( '/\d+(?:\.\d+)+/', (string) $composer_data['require']['php'], $composer_match );
-		$this->assertNotEmpty( $composer_match, 'Unable to parse PHP minimum version from composer.json require.php.' );
-		$composer_min_php = $composer_match[0];
-
-		$this->assertArrayHasKey( 'Requires PHP', self::$defined_readme_headers, "The readme.txt header 'Requires PHP' is missing." );
-		$readme_min_php = self::$defined_readme_headers['Requires PHP'];
-
-		$plugin_contents = file_get_contents( $plugin_file );
-		$this->assertNotFalse( $plugin_contents, 'Unable to read plugin file.' );
-
-		$function_pattern = '/function\s+minimum_php_requirement\s*\(\s*\)\s*\{[\s\S]*?return\s+[\"\']([^\"\']+)[\"\']\s*;/';
-		preg_match( $function_pattern, $plugin_contents, $plugin_match );
-		$this->assertNotEmpty( $plugin_match, 'Unable to parse minimum_php_requirement() return value from plugin file.' );
-		$function_min_php = $plugin_match[1];
-
-		$this->assertSame( $function_min_php, $readme_min_php, 'Minimum PHP version mismatch between minimum_php_requirement() and readme.txt Requires PHP.' );
-		$this->assertSame( $function_min_php, $composer_min_php, 'Minimum PHP version mismatch between minimum_php_requirement() and composer.json require.php.' );
-	}
-
-	/**
-	 * Test that the minimum WordPress version in readme matches the Cypress test config.
-	 */
-	public function test_minimum_wordpress_version_matches_cypress_config() {
-		$cypress_file = self::PLUGIN_ROOT_DIR . '/.github/workflows/cypress.yml';
-
-		$this->assertFileExists( $cypress_file, 'Cypress workflow file does not exist.' );
-
-		$cypress_contents = file_get_contents( $cypress_file );
-		$this->assertNotFalse( $cypress_contents, 'Unable to read cypress.yml.' );
-
-		// Extract the minimum WordPress version from the "WP minimum" matrix entry in cypress.yml.
-		// Looking for: - {name: 'WP minimum', version: 'WordPress/WordPress#x.x-branch'}
-		$pattern = '/\-\s*\{\s*name:\s*\'WP minimum\'\s*,\s*version:\s*\'WordPress\/WordPress#([\d.]+)\-branch\'/';
-		preg_match( $pattern, $cypress_contents, $cypress_match );
-		$this->assertNotEmpty( $cypress_match, 'Unable to parse minimum WordPress version from the "WP minimum" matrix entry in cypress.yml.' );
-		$cypress_min_wp = $cypress_match[1];
-
-		// Get the minimum WordPress version from the readme.
-		$this->assertArrayHasKey( 'Requires at least', self::$defined_readme_headers, "The readme.txt header 'Requires at least' is missing." );
-		$readme_min_wp = self::$defined_readme_headers['Requires at least'];
-
-		$this->assertSame( $readme_min_wp, $cypress_min_wp, "Minimum WordPress version mismatch between cypress.yml ({$cypress_min_wp}) and readme.txt Requires at least ({$readme_min_wp})." );
 	}
 
 	/**

--- a/tests/unit/test-plugin-version.php
+++ b/tests/unit/test-plugin-version.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Test plugin version is consistent in all locations.
+ * Test plugin version policy.
  *
  * @package safe-svg
  */
@@ -8,144 +8,11 @@
 use PHPUnit\Framework\TestCase;
 
 /**
- * The VersionTests class tests the plugin version is consistent in all locations.
+ * The VersionTests class tests plugin version policy that is not handled by Consistent Versions.
  */
 class PluginVersionTests extends TestCase {
 
 	const PLUGIN_ROOT_DIR = __DIR__ . '/../..';
-
-	/**
-	 * Helper function to get the plugin version from the plugin file constant.
-	 *
-	 * This is necessary to avoid hardcoding the version in the test, which would require updates to the test for every version bump and increase the risk of human error.
-	 *
-	 * @return string The plugin version as defined in the plugin file constant.
-	 * @throws RuntimeException If the plugin version cannot be determined.
-	 */
-	public static function get_plugin_version_constant() {
-		$plugin_file_name = 'safe-svg.php';
-
-		/*
-		 * Determine the value of `SAFE_SVG_VERSION` constant.
-		 *
-		 * This uses regex rather than including the plugin file to avoid side effects
-		 * caused by the use of mocks for the test suite.
-		 */
-		$plugin_file_contents = file_get_contents( self::PLUGIN_ROOT_DIR . "/{$plugin_file_name}" );
-		if ( false === $plugin_file_contents ) {
-			// phpcs:ignore
-			throw new RuntimeException( 'Unable to read plugin file: ' . self::PLUGIN_ROOT_DIR . "/{$plugin_file_name}" );
-		}
-
-		if ( preg_match( '/define\(\s*[\'"]SAFE_SVG_VERSION[\'"]\s*,\s*[\'"]([^\'"]+)[\'"]\s*\)/', $plugin_file_contents, $matches ) ) {
-			return $matches[1];
-		}
-
-		// phpcs:ignore
-		throw new RuntimeException( 'Unable to determine plugin version from file: ' . self::PLUGIN_ROOT_DIR . "/{$plugin_file_name}" );
-	}
-
-	/**
-	 * Helper function to read the file headers.
-	 *
-	 * Based on the get_file_data function in wp-includes/functions.php.
-	 *
-	 * @see https://developer.wordpress.org/reference/functions/get_file_data/
-	 *
-	 * @param string               $file            The file to read the headers from.
-	 * @param array<string,string> $default_headers List of headers, in the format array( 'HeaderKey' => 'Header Name' ).
-	 * @param string               $context         Unused. Included for consistency with the WP function signature.
-	 * @return array<string,string> Array of file header values keyed by header name.
-	 */
-	public static function get_file_data( string $file, array $default_headers, $context = '' ): array {
-		// Pull only the first 8 KB of the file in.
-		$file_data = file_get_contents( $file, false, null, 0, 8 * 1024 );
-
-		if ( false === $file_data ) {
-			$file_data = '';
-		}
-
-		// Make sure we catch CR-only line endings.
-		$file_data = str_replace( "\r", "\n", $file_data );
-
-		$all_headers = $default_headers;
-
-		foreach ( $all_headers as $field => $regex ) {
-			if ( preg_match( '/^(?:[ \t]*<\?php)?[ \t\/*#@]*' . preg_quote( $regex, '/' ) . ':(.*)$/mi', $file_data, $match ) && $match[1] ) {
-				$all_headers[ $field ] = trim( preg_replace( '/\s*(?:\*\/|\?>).*/', '', $match[1] ) );
-			} else {
-				$all_headers[ $field ] = '';
-			}
-		}
-
-		return $all_headers;
-	}
-
-	/**
-	 * Test Stable Tag in readme.txt matches plugin version.
-	 */
-	public function test_stable_tag_matches_plugin_version() {
-		$readme_file = self::PLUGIN_ROOT_DIR . '/readme.txt';
-		$readme_data = self::get_file_data(
-			$readme_file,
-			array(
-				'Stable tag' => 'Stable tag',
-			)
-		);
-
-		$this->assertSame( self::get_plugin_version_constant(), $readme_data['Stable tag'], 'The Stable tag in readme.txt does not match the plugin version.' );
-	}
-
-	/**
-	 * Test version header in the plugin file matches plugin version constant.
-	 */
-	public function test_plugin_version_header() {
-		// Get the plugin headers.
-		// Plugin name.
-		$plugin_file_name = 'safe-svg.php';
-
-		$plugin_file_data = self::get_file_data(
-			self::PLUGIN_ROOT_DIR . "/{$plugin_file_name}",
-			array(
-				'Version' => 'Version',
-			)
-		);
-
-		$this->assertSame( self::get_plugin_version_constant(), $plugin_file_data['Version'], 'The Version header in the plugin file does not match the plugin version constant.' );
-	}
-
-	/**
-	 * Test the plugin version in package.json matches the plugin version constant.
-	 */
-	public function test_package_json_version() {
-		$package_file = self::PLUGIN_ROOT_DIR . '/package.json';
-		if ( ! file_exists( $package_file ) ) {
-			// Package file does not exist, consider this test passed.
-			$this->assertTrue( true );
-			return;
-		}
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- fine for the tests.
-		$package_data = json_decode( file_get_contents( $package_file ), true );
-		$this->assertSame( self::get_plugin_version_constant(), $package_data['version'], 'The version in package.json does not match the plugin version constant.' );
-	}
-
-	/**
-	 * Test the plugin version in package-lock.json matches the plugin version constant.
-	 */
-	public function test_package_lock_json_version() {
-		$package_lock_file = self::PLUGIN_ROOT_DIR . '/package-lock.json';
-		if ( ! file_exists( $package_lock_file ) ) {
-			// Package lock file does not exist, consider this test passed.
-			$this->assertTrue( true );
-			return;
-		}
-
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- fine for the tests.
-		$package_lock_data = json_decode( file_get_contents( $package_lock_file ), true );
-		$this->assertSame( self::get_plugin_version_constant(), $package_lock_data['version'], 'The version in package-lock.json does not match the plugin version constant.' );
-		$this->assertSame( self::get_plugin_version_constant(), $package_lock_data['packages']['']['version'], "The packages['']['version'] in package-lock.json packages does not match the plugin version constant." );
-	}
 
 	/**
 	 * Ensure that composer.json does not have a version key.


### PR DESCRIPTION
# Description of the Change

Adds [Consistent Versions](https://github.com/szepeviktor/consistent-versions) configuration for plugin, PHP, and WordPress minimum version checks. This moves duplicated version consistency assertions out of PHPUnit and runs the dedicated consistency checker in the PHPUnit workflow.

# Changelog

- Changed: Replaced custom PHPUnit version consistency assertions with a Consistent Versions configuration and CI check.

# Credits

Props @szepeviktor.